### PR TITLE
[Tools] fix copy store id hotkey

### DIFF
--- a/convermax-tools.user.js
+++ b/convermax-tools.user.js
@@ -1,7 +1,7 @@
 ﻿// ==UserScript==
 // @name         Convermax Tools
 // @namespace    convermax-dev
-// @version      0.8.3
+// @version      0.8.4
 // @description  Convermax Tools
 // @downloadURL  https://github.com/Convermax/Utils/raw/main/convermax-tools.user.js
 // @updateURL    https://github.com/Convermax/Utils/raw/main/convermax-tools.user.js

--- a/convermax-tools.user.js
+++ b/convermax-tools.user.js
@@ -375,7 +375,7 @@ const actions = {
           GM_openInTab(`https://myconvermax.com/${actions.common.storeId}/status`, { active: true }),
       },
       {
-        hotkey: '`',
+        hotkey: 'Backquote',
         ctrlKey: true,
         action: () => GM_setClipboard(actions.common.storeId),
       },
@@ -435,7 +435,7 @@ function registerActions(commands) {
       document.addEventListener('keydown', (e) => {
         if (
           !e.shiftKey &&
-          e.key === hotkey &&
+          (e.key === hotkey || e.code === hotkey) &&
           ((ctrlKey && e.ctrlKey && !e.altKey) || (!ctrlKey && !e.ctrlKey && e.altKey))
         ) {
           e.preventDefault();


### PR DESCRIPTION
I've fixed the Copy StoreID hotkey. Now it works on any keyword layout.