### PR TITLE
[Tools] Fix request access & re-add btn to Partners store page

### DIFF
--- a/convermax-tools.user.js
+++ b/convermax-tools.user.js
@@ -1,7 +1,7 @@
 ﻿// ==UserScript==
 // @name         Convermax Tools
 // @namespace    convermax-dev
-// @version      0.12.0
+// @version      0.13.0
 // @description  Convermax Tools
 // @downloadURL  https://github.com/Convermax/Utils/raw/main/convermax-tools.user.js
 // @updateURL    https://github.com/Convermax/Utils/raw/main/convermax-tools.user.js
@@ -15,6 +15,7 @@
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @grant        unsafeWindow
+// @grant        window.onurlchange
 // @sandbox      JavaScript
 // @noframes
 // ==/UserScript==
@@ -610,6 +611,14 @@ function fixNoStoreAtShopifyPartners() {
   } else if (isPartnersSearch && isNoResults && url.includes('store_type=dev')) {
     window.location.replace(url.replace('store_type=dev', 'store_type=client_transfer'));
     return true;
+  } else if (isPartnersSearch && isNoResults && url.includes('store_type=client_transfer')) {
+    const requestButton = window.document.querySelector(
+      'a[href="/dashboard/129335902/stores/collaborations/new"]',
+    );
+    const storeId = new URL(url)?.searchParams?.get('search_term');
+    if (requestButton && storeId) {
+      requestButton.setAttribute('href', `${requestButton.getAttribute('href')}?store_url=${storeId}`);
+    }
   } else if (
     isPartnersSearch &&
     [...Results].length &&
@@ -744,6 +753,11 @@ function setupPermissionsButton() {
     'manage_delivery_settings',
   ];
 
+  if (window.location.href.includes('?store_url=')) {
+    const storeInput = window.document.querySelector('#store-url-input');
+    setTimeout(() => storeInput?.dispatchEvent(new Event('input', { bubbles: true })), 0);
+  }
+
   const targetButton = document.querySelector('#collaboration-request-submit-button');
 
   const button = document.createElement('button');
@@ -771,9 +785,34 @@ function setupPermissionsButton() {
   targetButton.parentNode.insertBefore(button, targetButton);
 }
 
-(function () {
-  'use strict';
+function injectShopifyPartnersStoreRequest() {
+  const header = window.document.querySelector('.ui-title-bar__main-group .ui-title-bar__heading-group');
+  const collaboratorStatus = window.document.querySelector(
+    '.ui-layout__section--secondary .ui-card__section .badge',
+  );
+  const storeId = window.document
+    .querySelector('a[href$=".myshopify.com"]')
+    ?.getAttribute('href')
+    ?.match(/https?:\/\/([^.]+)\.myshopify\.com/)?.[1];
+  const storeCode = window.location.pathname.split('/').filter(Boolean).at(-1);
 
+  if ((!collaboratorStatus || collaboratorStatus.textContent === 'Approved') && header && storeId) {
+    const button = document.createElement('a');
+    button.textContent = collaboratorStatus ? 'Log in' : `Request access`;
+    button.className = 'ui-button ui-button--primary';
+    button.style.marginLeft = 'auto';
+    button.setAttribute(
+      'href',
+      collaboratorStatus
+        ? `https://dev.shopify.com/dashboard/129335902/stores/${storeCode}/collaborator_login`
+        : `https://dev.shopify.com/dashboard/129335902/stores/collaborations/new?store_url=${storeId}`,
+    );
+
+    header.appendChild(button);
+  }
+}
+
+function main() {
   bypassShopifyStub();
   bypassBigCommerceStubInit();
 
@@ -797,7 +836,12 @@ function setupPermissionsButton() {
       setupPermissionsButton(),
     );
   }
-
+  if (/^https:\/\/partners\.shopify\.com\/201897\/stores\/\d+/.test(url)) {
+    ensureContextIsSet(
+      () => window.document.querySelector('.ui-title-bar__main-group .ui-title-bar__heading-group'),
+      10000,
+    ).then(() => injectShopifyPartnersStoreRequest());
+  }
   const redirectPath = GM_getValue('bypassBigCommerceStubLocation', '');
   const redirectURL = redirectPath ? new URL(redirectPath) : null;
   if (
@@ -808,4 +852,12 @@ function setupPermissionsButton() {
   ) {
     ensureContextIsSet(() => bypassBigCommerceStub(), 10000);
   }
+}
+
+(function () {
+  if (window.onurlchange === null) {
+    window.addEventListener('urlchange', main);
+  }
+
+  main();
 })();

--- a/convermax-tools.user.js
+++ b/convermax-tools.user.js
@@ -643,9 +643,9 @@ function bypassShopifyStub() {
     return true;
   }
 
-  const button = window.document.querySelector('s-internal-button:not([icon="view"])');
+  const viewStoreButton = window.document.querySelector('s-internal-button:not([icon="view"])');
 
-  if (button) {
+  if (viewStoreButton) {
     const _open = window.unsafeWindow.open;
     window.unsafeWindow.open = function (...args) {
       if (args[1] === '_blank') {
@@ -653,7 +653,7 @@ function bypassShopifyStub() {
       }
       return _open.apply(this, args);
     };
-    button?.click();
+    viewStoreButton?.click();
     return true;
   }
   return false;

--- a/convermax-tools.user.js
+++ b/convermax-tools.user.js
@@ -1,7 +1,7 @@
 ﻿// ==UserScript==
 // @name         Convermax Tools
 // @namespace    convermax-dev
-// @version      0.13.0
+// @version      0.14.0
 // @description  Convermax Tools
 // @downloadURL  https://github.com/Convermax/Utils/raw/main/convermax-tools.user.js
 // @updateURL    https://github.com/Convermax/Utils/raw/main/convermax-tools.user.js

--- a/convermax-tools.user.js
+++ b/convermax-tools.user.js
@@ -631,10 +631,32 @@ function fixNoStoreAtShopifyPartners() {
   return false;
 }
 
-function bypassShopifyStub() {
+function bypassShopifyStubInit() {
   if (window.location.pathname.match(/(\/\w{2})?\/password/) && actions.platforms.shopify.test()) {
+    GM_setValue('bypassShopifyStubStartedAt', Date.now());
     window.location.assign(`${window.location.origin}/admin/themes`);
   }
+}
+
+function bypassShopifyStub() {
+  if (isActionExpired('bypassShopifyStub')) {
+    return true;
+  }
+
+  const button = window.document.querySelector('s-internal-button:not([icon="view"])');
+
+  if (button) {
+    const _open = window.unsafeWindow.open;
+    window.unsafeWindow.open = function (...args) {
+      if (args[1] === '_blank') {
+        args[1] = '_self';
+      }
+      return _open.apply(this, args);
+    };
+    button?.click();
+    return true;
+  }
+  return false;
 }
 
 function ensureContextIsSet(getContext, timeout) {
@@ -813,7 +835,7 @@ function injectShopifyPartnersStoreRequest() {
 }
 
 function main() {
-  bypassShopifyStub();
+  bypassShopifyStubInit();
   bypassBigCommerceStubInit();
 
   ensureContextIsSet(() => actions.platforms.some((p) => p.test()), 10000).then(() => {
@@ -841,6 +863,12 @@ function main() {
       () => window.document.querySelector('.ui-title-bar__main-group .ui-title-bar__heading-group'),
       10000,
     ).then(() => injectShopifyPartnersStoreRequest());
+  }
+  if (
+    !isActionExpired('bypassShopifyStub') &&
+    /^https:\/\/admin\.shopify\.com\/store\/[^/]+\/themes/.test(url)
+  ) {
+    ensureContextIsSet(() => bypassShopifyStub(), 10000);
   }
   const redirectPath = GM_getValue('bypassBigCommerceStubLocation', '');
   const redirectURL = redirectPath ? new URL(redirectPath) : null;


### PR DESCRIPTION
[SS-10678](https://tasks.convermax.com/issue/SS-10678) [Tools] Migrate Shopify Partner store lookup URLs to the new Dev Dashboard
Follow-up for 578f220c94cbc1b9326b4d02a440f313f9c0676b

These changes are aimed at restoring a comfortable flow
- Implement a proper stub bypass for Shopify password-protected stores, right to the store page instead of admin panel (doesn't restore the initially requested page for now tho)
- Fix the Select permissions button injection to the new Dev Dashboard store access request page 
  - achieved by making the whole script support SPAs via `onurlchange`
- Inject the searched store ID into the request store access button if the search wasn't successful 
  - so you can automatically end up on the access request page after trying to open a password-protected store we don't yet have access to
- Re-add the Log in / Request access button to the old partners portal store page, recently removed by Shopify
  - No access: https://partners.shopify.com/201897/stores/70282641666
  - Approved: https://partners.shopify.com/201897/stores/99483812153
  - Pending: https://partners.shopify.com/201897/stores/93491528065
<details>
<summary>Screenshot</summary>
<img width="1749" height="1282" alt="image" src="https://github.com/user-attachments/assets/0ccbca88-977b-449c-8044-fe58cbdca90f" />

</details>